### PR TITLE
update StripeHandler after component update to refresh the configuration

### DIFF
--- a/StripeCheckout.jsx
+++ b/StripeCheckout.jsx
@@ -129,7 +129,7 @@ var ReactStripeCheckout = React.createClass({
 
   statics: {
     stripeHandler: null,
-    scriptDidError: false,
+    scriptDidError: false
   },
 
   hasPendingClick: false,
@@ -139,22 +139,27 @@ var ReactStripeCheckout = React.createClass({
     // Initialize the Stripe handler on the first onScriptLoaded call.
     // This handler is shared by all StripeButtons on the page.
     if (!ReactStripeCheckout.stripeHandler) {
-      this.config.key = this.props.stripeKey;
-      var options = [
-        'token', 'image', 'name', 'description', 'amount', 'currency', 'closed',
-        'panelLabel', 'zipCode', 'email', 'allowRememberMe', 'bitcoin', 'opened',
-      ];
-      for (var i=0; i<options.length; i++) {
-        var key = options[i];
-        if (key in this.props) {
-          this.config[key] = this.props[key];
-        }
-      }
-      ReactStripeCheckout.stripeHandler = StripeCheckout.configure(this.config);
-      if (this.hasPendingClick) {
-        this.showStripeDialog();
+      this.updateStripeHandler();
+    }
+  },
+
+  updateStripeHandler: function () {
+    this.config.key = this.props.stripeKey;
+    var options = ['token', 'image', 'name', 'description', 'amount', 'currency', 'closed', 'panelLabel', 'zipCode', 'email', 'allowRememberMe', 'bitcoin', 'opened'];
+    for (var i = 0; i < options.length; i++) {
+      var key = options[i];
+      if (key in this.props) {
+        this.config[key] = this.props[key];
       }
     }
+    ReactStripeCheckout.stripeHandler = StripeCheckout.configure(this.config);
+    if (this.hasPendingClick) {
+      this.showStripeDialog();
+    }
+  },
+
+  componentDidUpdate: function () {
+    this.updateStripeHandler();
   },
 
   showLoadingDialog: function() {

--- a/dist/react-stripe-checkout.js
+++ b/dist/react-stripe-checkout.js
@@ -129,19 +129,27 @@ var ReactStripeCheckout = React.createClass({
     // Initialize the Stripe handler on the first onScriptLoaded call.
     // This handler is shared by all StripeButtons on the page.
     if (!ReactStripeCheckout.stripeHandler) {
-      this.config.key = this.props.stripeKey;
-      var options = ['token', 'image', 'name', 'description', 'amount', 'currency', 'closed', 'panelLabel', 'zipCode', 'email', 'allowRememberMe', 'bitcoin', 'opened'];
-      for (var i = 0; i < options.length; i++) {
-        var key = options[i];
-        if (key in this.props) {
-          this.config[key] = this.props[key];
-        }
-      }
-      ReactStripeCheckout.stripeHandler = StripeCheckout.configure(this.config);
-      if (this.hasPendingClick) {
-        this.showStripeDialog();
+      this.updateStripeHandler();
+    }
+  },
+
+  updateStripeHandler: function updateStripeHandler() {
+    this.config.key = this.props.stripeKey;
+    var options = ['token', 'image', 'name', 'description', 'amount', 'currency', 'closed', 'panelLabel', 'zipCode', 'email', 'allowRememberMe', 'bitcoin', 'opened'];
+    for (var i = 0; i < options.length; i++) {
+      var key = options[i];
+      if (key in this.props) {
+        this.config[key] = this.props[key];
       }
     }
+    ReactStripeCheckout.stripeHandler = StripeCheckout.configure(this.config);
+    if (this.hasPendingClick) {
+      this.showStripeDialog();
+    }
+  },
+
+  componentDidUpdate: function componentDidUpdate() {
+    this.updateStripeHandler();
   },
 
   showLoadingDialog: function showLoadingDialog() {
@@ -193,3 +201,4 @@ var ReactStripeCheckout = React.createClass({
 });
 
 module.exports = ReactStripeCheckout;
+


### PR DESCRIPTION
This is what I have: 

![image](https://cloud.githubusercontent.com/assets/10519489/8744528/1abb7286-2c78-11e5-9807-7e63ba75f738.png)

The problem is that when the state.price is updated Stripe is still showing the initial price even though StripeCheckout is re-rendered.

It seems like StripeHandler should be updated on each rendering for this to work and not only on onScriptLoaded. I did get it to work by extracting updateStripeHandler function and calling it on componentDidUpdate and it seems to work now but I am new to react so there may be something I am missing here..