### PR TITLE
Support billingAddress and shippingAddress options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,17 @@ var TakeMoney = React.createClass({
   currency="USD"
   stripeKey="..."
   locale="zh"
+  email={foo@bar.com}
+  // Note: Enabling either address option will give the user the ability to
+  // fill out both.
+  shippingAddress={false}
+  billingAddress={false}
+  // Note: enabling both zipCode checks and billing or shipping address can have
+  // unintended consequences.
+  zipCode={false}
   alipay={true}
   bitcoin={true}
+  allowRememberme={true}
   token={this.onToken}>
   <button className="myOwnButton">
     <span>Use your own child component, which gets wrapped in a

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var TakeMoney = React.createClass({
   locale="zh"
   email={foo@bar.com}
   // Note: Enabling either address option will give the user the ability to
-  // fill out both.
+  // fill out both. Addresses are sent as a second parameter in the token callback.
   shippingAddress={false}
   billingAddress={false}
   // Note: enabling both zipCode checks and billing or shipping address can have

--- a/StripeCheckout.jsx
+++ b/StripeCheckout.jsx
@@ -113,6 +113,14 @@ var ReactStripeCheckout = React.createClass({
     // false)
     zipCode: React.PropTypes.bool,
 
+    // Specify whether Checkout should collect the user's billing address
+    // (true or false). The default is false.
+    billingAddress: React.PropTypes.bool,
+
+    // Specify whether Checkout should collect the user's shipping address
+    // (true or false). The default is false.
+    shippingAddress: React.PropTypes.bool,
+
     // Specify whether Checkout should validate the billing ZIP code (true or
     // false). The default is false.
     email: React.PropTypes.string,
@@ -195,8 +203,9 @@ var ReactStripeCheckout = React.createClass({
     config.key = this.props.stripeKey;
     var options = [
       'token', 'image', 'name', 'description', 'amount', 'locale',
-      'currency', 'panelLabel', 'zipCode', 'email', 'allowRememberMe',
-      'bitcoin', 'alipay', 'alipayReusable', 'opened', 'closed'
+      'currency', 'panelLabel', 'zipCode', 'shippingAddress',
+      'billingAddress', 'email', 'allowRememberMe', 'bitcoin',
+      'alipay', 'alipayReusable', 'opened', 'closed'
     ];
     for (var i = 0; i < options.length; i++) {
       var key = options[i];
@@ -248,4 +257,3 @@ var ReactStripeCheckout = React.createClass({
 });
 
 module.exports = ReactStripeCheckout;
-

--- a/dist/react-stripe-checkout.js
+++ b/dist/react-stripe-checkout.js
@@ -102,6 +102,14 @@ var ReactStripeCheckout = React.createClass({
     // false)
     zipCode: React.PropTypes.bool,
 
+    // Specify whether Checkout should collect the user's billing address
+    // (true or false). The default is false.
+    billingAddress: React.PropTypes.bool,
+
+    // Specify whether Checkout should collect the user's shipping address
+    // (true or false). The default is false.
+    shippingAddress: React.PropTypes.bool,
+
     // Specify whether Checkout should validate the billing ZIP code (true or
     // false). The default is false.
     email: React.PropTypes.string,
@@ -179,7 +187,7 @@ var ReactStripeCheckout = React.createClass({
   getConfig: function getConfig() {
     var config = {};
     config.key = this.props.stripeKey;
-    var options = ['token', 'image', 'name', 'description', 'amount', 'locale', 'currency', 'panelLabel', 'zipCode', 'email', 'allowRememberMe', 'bitcoin', 'alipay', 'alipayReusable', 'opened', 'closed'];
+    var options = ['token', 'image', 'name', 'description', 'amount', 'locale', 'currency', 'panelLabel', 'zipCode', 'shippingAddress', 'billingAddress', 'email', 'allowRememberMe', 'bitcoin', 'alipay', 'alipayReusable', 'opened', 'closed'];
     for (var i = 0; i < options.length; i++) {
       var key = options[i];
       if (key in this.props) {


### PR DESCRIPTION
Hello! Thanks for this nice component.

I needed to enable support of Checkout's `shippingAddress` and `billingAddress` options for a project, so I went ahead and took the liberty of adding them.

Per https://mattarkin.com/how-to-get-billing-and-shipping-address-data-from-stripe-checkout/, the addresses are passed in a second variable to the `token` callback. There's some weirdness with using both address options and `zipCode`, but it's technically supported, so I added a warning to [README.md](README.md) instead of checking for truthiness of both.

Cheers!