### PR TITLE
Check changed props before updating StripeHandler

### DIFF
--- a/StripeCheckout.jsx
+++ b/StripeCheckout.jsx
@@ -188,9 +188,19 @@ var ReactStripeCheckout = React.createClass({
     }
   },
 
-  componentDidUpdate: function () {
-    if (!this.state.scriptLoading)
+  componentDidUpdate: function (prevProps) {
+    if (!this.state.scriptLoading && this.stripeHandlerMustUpdate(prevProps))
       this.updateStripeHandler();
+  },
+
+  stripeHandlerMustUpdate: function(prevProps) {
+    var handlerProps = ['key', 'token', 'image', 'locale'];
+    for (var i = 0; i < handlerProps.length; i++) {
+      var prop = handlerProps[i];
+      if (prevProps[prop] !== this.props[prop])
+        return true;
+    }
+    return false;
   },
 
   showLoadingDialog: function() {

--- a/StripeCheckout.jsx
+++ b/StripeCheckout.jsx
@@ -176,7 +176,7 @@ var ReactStripeCheckout = React.createClass({
     this.setState({scriptLoading: false});
     // Initialize the Stripe handler on the first onScriptLoaded call.
     // This handler is shared by all StripeButtons on the page.
-    if (this.isMounted() && !ReactStripeCheckout.stripeHandler) {
+    if (!ReactStripeCheckout.stripeHandler) {
       this.updateStripeHandler();
     }
   },
@@ -185,12 +185,6 @@ var ReactStripeCheckout = React.createClass({
     ReactStripeCheckout.stripeHandler = StripeCheckout.configure(this.getConfig());
     if (this.hasPendingClick) {
       this.showStripeDialog();
-    }
-  },
-
-  componentDidMount: function () {
-    if(!this.state.scriptLoading && !ReactStripeCheckout.stripeHandler) {
-      this.updateStripeHandler();
     }
   },
 

--- a/StripeCheckout.jsx
+++ b/StripeCheckout.jsx
@@ -176,7 +176,7 @@ var ReactStripeCheckout = React.createClass({
     this.setState({scriptLoading: false});
     // Initialize the Stripe handler on the first onScriptLoaded call.
     // This handler is shared by all StripeButtons on the page.
-    if (!ReactStripeCheckout.stripeHandler) {
+    if (this.isMounted() && !ReactStripeCheckout.stripeHandler) {
       this.updateStripeHandler();
     }
   },
@@ -185,6 +185,12 @@ var ReactStripeCheckout = React.createClass({
     ReactStripeCheckout.stripeHandler = StripeCheckout.configure(this.getConfig());
     if (this.hasPendingClick) {
       this.showStripeDialog();
+    }
+  },
+
+  componentDidMount: function () {
+    if(!this.state.scriptLoading && !ReactStripeCheckout.stripeHandler) {
+      this.updateStripeHandler();
     }
   },
 

--- a/dist/react-stripe-checkout.js
+++ b/dist/react-stripe-checkout.js
@@ -165,7 +165,7 @@ var ReactStripeCheckout = React.createClass({
     this.setState({ scriptLoading: false });
     // Initialize the Stripe handler on the first onScriptLoaded call.
     // This handler is shared by all StripeButtons on the page.
-    if (!ReactStripeCheckout.stripeHandler) {
+    if (this.isMounted() && !ReactStripeCheckout.stripeHandler) {
       this.updateStripeHandler();
     }
   },
@@ -174,6 +174,12 @@ var ReactStripeCheckout = React.createClass({
     ReactStripeCheckout.stripeHandler = StripeCheckout.configure(this.getConfig());
     if (this.hasPendingClick) {
       this.showStripeDialog();
+    }
+  },
+
+  componentDidMount: function componentDidMount() {
+    if (!this.state.scriptLoading && !ReactStripeCheckout.stripeHandler) {
+      this.updateStripeHandler();
     }
   },
 

--- a/dist/react-stripe-checkout.js
+++ b/dist/react-stripe-checkout.js
@@ -177,8 +177,17 @@ var ReactStripeCheckout = React.createClass({
     }
   },
 
-  componentDidUpdate: function componentDidUpdate() {
-    if (!this.state.scriptLoading) this.updateStripeHandler();
+  componentDidUpdate: function componentDidUpdate(prevProps) {
+    if (!this.state.scriptLoading && this.stripeHandlerMustUpdate(prevProps)) this.updateStripeHandler();
+  },
+
+  stripeHandlerMustUpdate: function stripeHandlerMustUpdate(prevProps) {
+    var handlerProps = ['key', 'token', 'image', 'locale'];
+    for (var i = 0; i < handlerProps.length; i++) {
+      var prop = handlerProps[i];
+      if (prevProps[prop] !== this.props[prop]) return true;
+    }
+    return false;
   },
 
   showLoadingDialog: function showLoadingDialog() {
@@ -244,4 +253,3 @@ var ReactStripeCheckout = React.createClass({
 });
 
 module.exports = ReactStripeCheckout;
-

--- a/dist/react-stripe-checkout.js
+++ b/dist/react-stripe-checkout.js
@@ -165,7 +165,7 @@ var ReactStripeCheckout = React.createClass({
     this.setState({ scriptLoading: false });
     // Initialize the Stripe handler on the first onScriptLoaded call.
     // This handler is shared by all StripeButtons on the page.
-    if (this.isMounted() && !ReactStripeCheckout.stripeHandler) {
+    if (!ReactStripeCheckout.stripeHandler) {
       this.updateStripeHandler();
     }
   },
@@ -174,12 +174,6 @@ var ReactStripeCheckout = React.createClass({
     ReactStripeCheckout.stripeHandler = StripeCheckout.configure(this.getConfig());
     if (this.hasPendingClick) {
       this.showStripeDialog();
-    }
-  },
-
-  componentDidMount: function componentDidMount() {
-    if (!this.state.scriptLoading && !ReactStripeCheckout.stripeHandler) {
-      this.updateStripeHandler();
     }
   },
 


### PR DESCRIPTION
This fixes a bug (#10) that forced the StripeHandler to be updated (initiating a remote request) whenever the component was updated. I've added a method that checks to ensure that the prop changes received actually necessitate a handler update.

I think the next step along this path would be to spit `getConfig` into `getHandlerConfig` and `getOpenConfig` to stop unnecessary props from being passed to different Checkout methods.