### PR TITLE
Trigger modal to open based on a prop boolean value

### DIFF
--- a/StripeCheckout.jsx
+++ b/StripeCheckout.jsx
@@ -254,6 +254,11 @@ var ReactStripeCheckout = React.createClass({
       this.onClick()
     }
     var ComponentClass = this.props.componentClass;
+    if(this.props.showModal !== null) {
+      return React.createElement(
+        ComponentClass
+      )
+    }
     return (
       !this.props.children ? this.renderStripeButton() : (
         <ComponentClass {...this.props} onClick={this.onClick}>

--- a/StripeCheckout.jsx
+++ b/StripeCheckout.jsx
@@ -250,6 +250,9 @@ var ReactStripeCheckout = React.createClass({
   },
 
   render: function () {
+    if(this.props.showModal) {
+      this.onClick()
+    }
     var ComponentClass = this.props.componentClass;
     return (
       !this.props.children ? this.renderStripeButton() : (

--- a/dist/react-stripe-checkout.js
+++ b/dist/react-stripe-checkout.js
@@ -238,6 +238,9 @@ var ReactStripeCheckout = React.createClass({
       this.onClick();
     }
     var ComponentClass = this.props.componentClass;
+    if (this.props.showModal !== null) {
+      return React.createElement(ComponentClass);
+    }
     return !this.props.children ? this.renderStripeButton() : React.createElement(
       ComponentClass,
       _extends({}, this.props, { onClick: this.onClick }),

--- a/dist/react-stripe-checkout.js
+++ b/dist/react-stripe-checkout.js
@@ -234,6 +234,9 @@ var ReactStripeCheckout = React.createClass({
   },
 
   render: function render() {
+    if (this.props.showModal) {
+      this.onClick();
+    }
     var ComponentClass = this.props.componentClass;
     return !this.props.children ? this.renderStripeButton() : React.createElement(
       ComponentClass,


### PR DESCRIPTION
This a **temporary solution**, but think you should implement it better than my solution. This basically triggers the stripe modal to show based on a boolean value. Would prefer to have a prop that triggers the stripe modal to open up without having to click on the button.

Basically I wanted the stripe modal to open after a validation check is done on a form. Once the form was valid then the stripe modal is triggered to open. Currently you only have an `onClick` that triggers the modal to open.

**ISSUE:** The only issue is that once the modal opens and the user closes it, it won't be opened again. That's because say you have a boolean value in your state that you initially set with `false`. Then you change it to `true` and the modal opens up. When you close the modal, that state value is still set to `true`. Which when you try to trigger the modal again, it won't open. My temporary solution was to do a `setTimeout` and reset that boolean to `false` after 1 second.

Also, the prop name (showModal) is not a good name. Doesn't communicate that it is a trigger boolean for the modal to open up. So definitely use another name.

Hope this clears what I'm trying to get across.