### PR TITLE
Fix onclick not trigger if bound to React synthesis event system in Chrome iOS

### DIFF
--- a/StripeCheckout.jsx
+++ b/StripeCheckout.jsx
@@ -259,17 +259,23 @@ var ReactStripeCheckout = React.createClass({
 
   renderStripeButton: function() {
     return (
-      <button className="stripe-checkout-button" onClick={this.onClick}>
+      <button className="stripe-checkout-button" ref={this.bindNativeOnClick}>
         <span className="inner-text">{this.props.label}</span>
       </button>
     );
+  },
+    
+  bindNativeOnClick: function(element) {
+    if (element !== null) {
+      element.onclick = this.onClick;
+    }
   },
 
   render: function () {
     var ComponentClass = this.props.componentClass;
     return (
       !this.props.children ? this.renderStripeButton() : (
-        <ComponentClass {...this.props} onClick={this.onClick}>
+        <ComponentClass {...this.props} ref={this.bindNativeOnClick}>
           {this.props.children}
         </ComponentClass>
       )

--- a/dist/react-stripe-checkout.js
+++ b/dist/react-stripe-checkout.js
@@ -241,7 +241,7 @@ var ReactStripeCheckout = React.createClass({
   renderStripeButton: function renderStripeButton() {
     return React.createElement(
       'button',
-      { className: 'stripe-checkout-button', onClick: this.onClick },
+      { className: 'stripe-checkout-button', ref: this.bindNativeOnClick },
       React.createElement(
         'span',
         { className: 'inner-text' },
@@ -250,11 +250,17 @@ var ReactStripeCheckout = React.createClass({
     );
   },
 
+  bindNativeOnClick: function bindNativeOnClick(element) {
+    if (element !== null) {
+      element.onclick = this.onClick;
+    }
+  },
+
   render: function render() {
     var ComponentClass = this.props.componentClass;
     return !this.props.children ? this.renderStripeButton() : React.createElement(
       ComponentClass,
-      _extends({}, this.props, { onClick: this.onClick }),
+      _extends({}, this.props, { ref: this.bindNativeOnClick }),
       this.props.children
     );
   }


### PR DESCRIPTION
I recently run into a problem specifically to Chrome iOS where the call to stripeHandler.open() just failed silently. After pinging Stripe support team, it's turn out that you need to call the open() function inside a *real* onClick handler, not from React's synthesis event system. 

The reason is Stripe trying to call window.open() on mobile and Chrome iOS only opens new tab if the handler is bound to a DOM-onclick handler and triggered by the user's click/touch action.

Here is a jsfiddle to demonstrate the fix on chrome: https://jsfiddle.net/fredstr/joq1v4xL/