### PR TITLE
Fix "Type mismatch for option" warnings

### DIFF
--- a/StripeCheckout.js
+++ b/StripeCheckout.js
@@ -306,9 +306,9 @@ export default class ReactStripeCheckout extends React.Component {
     'bitcoin',
     'alipay',
     'alipayReusable',
-  ].reduce((config, key) => Object.assign({}, config, {
-    [key]: this.props[key],
-  }), {
+  ].reduce((config, key) => key in this.props
+      ? Object.assign({}, config, {[key]: this.props[key]})
+      : config, {
     opened: this.onOpened,
     closed: this.onClosed,
   });


### PR DESCRIPTION
`getConfig()` returned all possible configuration options even ones that were not defined as component's properties. As a result, Stripe displayed warnings in the console about config options being undefined instead of type string, boolean, etc.

This is how it looked like in Chrome console:

![image](https://cloud.githubusercontent.com/assets/6132086/17567168/a391a5c0-5f81-11e6-8500-3e37bb7e4d6c.png)

This commit fixes this issue by skipping configuration options that haven't been defined as component's properties.