### PR TITLE
Fix Object.assign() errors in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-register": "^6.11.6",
     "enzyme": "^2.4.1",
     "eslint": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
       "es2015",
       "react",
       "stage-0"
+    ],
+    "plugins": [
+      "transform-object-assign"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
Object.assign() throws errors in IE11, use [babel-plugin-transform-object-assign](https://www.npmjs.com/package/babel-plugin-transform-object-assign) to fix.