### PR TITLE
Update stripe handler with multiple stripe accounts

### DIFF
--- a/StripeCheckout.js
+++ b/StripeCheckout.js
@@ -199,7 +199,7 @@ export default class ReactStripeCheckout extends React.Component {
   componentDidMount() {
     this._isMounted = true;
     if (scriptLoaded) {
-      return;
+      return this.updateStripeHandler();
     }
 
     if (scriptLoading) {


### PR DESCRIPTION
Possibly connected to #103 
I have multiple stripe accounts (different keys) but in order to change account the user needs to navigate away from the page that contains stripe-checkout.

In my use case the first page load calls `componentDidMount` which sets the correct api key. Requests to stripe at this point work correctly.
Then the user changes page (go to settings to change stripe account) and goes back to the previous payment screen, but now the stripe api key is different. However since the previous component was already unmounted, react calls again `componentDidMount` instead of `componentDidUpdate` so internally the api key stays the same and my requests fail.

I've added a call to `updateStripeHandler` which itself will check if the `this.props.reconfigureOnUpdate` is `true` and if so, reconfigure the already loaded handler.