### PR TITLE
Remove reconfigureOnUpdate prop. Reconfigure whenever stripeKey changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,6 @@ This will give you a default *Stripe-style* button which looks like this:
   token={this.onToken} // submit callback
   opened={this.onOpened} // called when the checkout popin is opened (no IE6/7)
   closed={this.onClosed} // called when the checkout popin is closed (no IE6/7)
-  // Note: `reconfigureOnUpdate` should be set to true IFF, for some reason
-  // you are using multiple stripe keys
-  reconfigureOnUpdate={false}
   // Note: you can change the event to `onTouchTap`, `onClick`, `onTouchStart`
   // useful if you're using React-Tap-Event-Plugin
   triggerEvent="onTouchTap"
@@ -106,7 +103,7 @@ This will give you a default *Stripe-style* button which looks like this:
 ### Other info
 This was probably terribly written, I'll look at any PR coming my way.
 
-### Resources 
+### Resources
 
 * [Accept Stripe Payments with React and Express](https://www.robinwieruch.de/react-express-stripe-payment/)
 

--- a/StripeCheckout.js
+++ b/StripeCheckout.js
@@ -11,7 +11,6 @@ export default class ReactStripeCheckout extends React.Component {
     label: 'Pay With Card',
     locale: 'auto',
     ComponentClass: 'span',
-    reconfigureOnUpdate: false,
     triggerEvent: 'onClick',
   }
 
@@ -56,13 +55,6 @@ export default class ReactStripeCheckout extends React.Component {
 
     // Runs when the script tag is created, but before it is added to the DOM
     onScriptTagCreated: PropTypes.func,
-
-    // By default, any time the React component is updated, it will call
-    // StripeCheckout.configure, which may result in additional XHR calls to the
-    // stripe API.  If you know the first configuration is all you need, you
-    // can set this to false.  Subsequent updates will affect the StripeCheckout.open
-    // (e.g. different prices)
-    reconfigureOnUpdate: PropTypes.bool,
 
     // =====================================================
     // Required by stripe
@@ -199,6 +191,7 @@ export default class ReactStripeCheckout extends React.Component {
   componentDidMount() {
     this._isMounted = true;
     if (scriptLoaded) {
+      this.updateStripeHandler();
       return;
     }
 
@@ -250,8 +243,8 @@ export default class ReactStripeCheckout extends React.Component {
     document.body.appendChild(script);
   }
 
-  componentDidUpdate() {
-    if (!scriptLoading) {
+  componentDidUpdate(prevProps) {
+    if (!scriptLoading && this.props.stripeKey !== prevProps.stripeKey) {
       this.updateStripeHandler();
     }
   }
@@ -267,13 +260,11 @@ export default class ReactStripeCheckout extends React.Component {
   }
 
   onScriptLoaded = () => {
-    if (!ReactStripeCheckout.stripeHandler) {
-      ReactStripeCheckout.stripeHandler = StripeCheckout.configure({
-        key: this.props.stripeKey,
-      });
-      if (this.hasPendingClick) {
-        this.showStripeDialog();
-      }
+    ReactStripeCheckout.stripeHandler = StripeCheckout.configure({
+      key: this.props.stripeKey,
+    });
+    if (this.hasPendingClick) {
+      this.showStripeDialog();
     }
   }
 
@@ -324,11 +315,9 @@ export default class ReactStripeCheckout extends React.Component {
   });
 
   updateStripeHandler() {
-    if (!ReactStripeCheckout.stripeHandler || this.props.reconfigureOnUpdate) {
-      ReactStripeCheckout.stripeHandler = StripeCheckout.configure({
-        key: this.props.stripeKey,
-      });
-    }
+    ReactStripeCheckout.stripeHandler = StripeCheckout.configure({
+      key: this.props.stripeKey,
+    });
   }
 
   showLoadingDialog(...args) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,6 @@ declare module "react-stripe-checkout" {
         alipay?: boolean
         bitcoin?: boolean
         allowRememberMe?: boolean
-        reconfigureOnUpdate?: boolean
         triggerEvent?: "onTouchTap" | "onClick" | "onTouchStart"
     }
 

--- a/spec.js
+++ b/spec.js
@@ -24,7 +24,6 @@ const props = {
   alipay: false,
   bitcoin: false,
   allowRememberMe: false,
-  reconfigureOnUpdate: false,
   triggerEvent: 'onClick',
   className: 'StripeCheckout'
 }


### PR DESCRIPTION
This removes the need for `reconfigureOnUpdate`. It didn't work right. It would cause stripe to update too often and wasn't necessary. Now we just watch for `stripeKey` to change. I've been using this code in production for a few months.