### PR TITLE
Add missing prop types in component typings declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,8 @@ declare module "react-stripe-checkout" {
 
     export interface StripeCheckoutProps {
         token(token: Token, address?: Address)
+        opened?()
+        closed?()
         stripeKey: string
         label?: string
         name?: string


### PR DESCRIPTION
This PR adds missing `closed` and `open` props in typings declaration.

Fixes #112 