### PR TITLE
Add types for  `opened` and `closed`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,8 @@ declare module "react-stripe-checkout" {
         allowRememberMe?: boolean
         reconfigureOnUpdate?: boolean
         triggerEvent?: "onTouchTap" | "onClick" | "onTouchStart"
+        opened?: (this: StripeCheckoutProps, ...args: any[]) => void
+        closed?: (this: StripeCheckoutProps, ...args: any[]) => void
     }
 
     import React = require("react")


### PR DESCRIPTION
Types for `StripeCheckoutProps` should include [`opened`](https://github.com/azmenak/react-stripe-checkout/blob/master/StripeCheckout.js#L182) and [`closed`](https://github.com/azmenak/react-stripe-checkout/blob/master/StripeCheckout.js#L186).

Types are infered from [this](https://github.com/azmenak/react-stripe-checkout/blob/master/StripeCheckout.js#L291) [code](https://github.com/azmenak/react-stripe-checkout/blob/master/StripeCheckout.js#L298).